### PR TITLE
additional serviceaccounts in values

### DIFF
--- a/setup/helm/operator/templates/operator-service-account-rbac-openshift.yaml
+++ b/setup/helm/operator/templates/operator-service-account-rbac-openshift.yaml
@@ -233,6 +233,12 @@ subjects:
 - kind: ServiceAccount
   name: postgres-operator
   namespace: {{ .Values.operatorSettings.operator_namespace }}
+# loop through additional target namespaces
+{{- range .Values.operatorSettings.subjects }}
+- kind: ServiceAccount
+  name: postgres-operator
+  namespace: {{ .namespace }}
+{{- end }}
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
Add the possibility to define additional serviceAccounts in the Helm value file(s).