### PR TITLE
Create pgbackrest example configuration for GCS

### DIFF
--- a/cluster-tutorials/pgbackrest_with_gcs/README.md
+++ b/cluster-tutorials/pgbackrest_with_gcs/README.md
@@ -1,0 +1,29 @@
+# pgbackrest with GCS
+
+## Creating the key.json file
+
+The key.json file should be created on an appropriate GCP IAM service account with at least the minimum permissions for
+GCS to read/write to your bucket.  Once the keyfile is downloaded, it should be created as a secret within kubernetes using
+either the appropriate ci/cd pipelines (leveraging an engine like Vault), or via:
+
+```
+kubectl create secret generic gcs-credentials --from-file=/path/to/key.json
+```
+
+## Method 1: operator configuration
+
+The operator needs the following configuration enabled to mount the gcs-credentials secret in all postgres containers:
+
+```
+configuration:
+  aws_or_gcp:
+    additional_secret_mount: gcs-credentials
+    additional_secret_mount_path: /var/secrets/google
+    gcp_credentials: /var/secrets/google/key.json
+```
+
+## Method 2: per-cluster configuration
+
+Alternatively you could utilize additionalVolumes in postgres.yaml to mount cluster-specific secrets in the postgresql cluster, 
+but if you change the name or the path that the keyfile is mounted to, you need to update spec.backup.pgbackrest.global.repo1-gcs-key
+in postgres.yaml to match.

--- a/cluster-tutorials/pgbackrest_with_gcs/postgres.yaml
+++ b/cluster-tutorials/pgbackrest_with_gcs/postgres.yaml
@@ -1,0 +1,35 @@
+apiVersion: cpo.opensource.cybertec.at/v1
+kind: postgresql
+metadata:
+  name: cluster-1
+spec:
+  dockerImage: 'docker.io/cybertecpostgresql/cybertec-pg-container:postgres-16.3-1'
+  numberOfInstances: 1
+  postgresql:
+    version: '16'
+  resources:
+    limits:
+      cpu: 500m
+      memory: 500Mi
+    requests:
+      cpu: 500m
+      memory: 500Mi
+  teamId: acid
+  volume:
+    size: 5Gi
+  backup:
+    pgbackrest:
+      global:
+        repo1-gcs-key: /var/secrets/google/key.json
+        repo1-gcs-key-type: service
+        repo1-path: /YOUR_PATH_INSIDE_THE_BUCKET/repo1/
+        repo1-retention-full: '7'
+        repo1-retention-full-type: count
+      image: docker.io/cybertecpostgresql/cybertec-pg-container:pgbackrest-16.3-1
+      repos:
+        - endpoint: YOUR_GCS_ENDPOINT
+          name: repo1
+          resource: YOUR_BUCKET_NAME
+          schedule:
+            full: 30 2 * * *
+          storage: gcs

--- a/setup/helm/operator/values.yaml
+++ b/setup/helm/operator/values.yaml
@@ -15,7 +15,7 @@ imagePullSecretNames: []
 
 # Define the operator settings to add to the configmap
 operatorSettings:
-  operatorImage: 'docker.io/cybertecpostgresql/cybertec-pg-operator:v0.7.0-1'
+  operatorImage: 'docker.io/cybertecpostgresql/cybertec-pg-operator-dev:v0.7.0-2'
   postgresImage: 'docker.io/cybertecpostgresql/cybertec-pg-container:postgres-16.3-1'
   poolerImage: 'docker.io/cybertecpostgresql/cybertec-pg-container:pgbouncer-1.22-1'
   watched_namespace: '*'


### PR DESCRIPTION
This PR adds an example configuration to utilize GCS with pgbackrest.  It contains a README that discusses two approaches to mounting a GCP IAM service account key into the containers and will likely be updated in the future when I finish ironing out the configuration for `repo1-gcs-key-type: auto`.

While here, update the operator image to the latest for the pooler removal bugfix.